### PR TITLE
python3, njit qmax and dmax

### DIFF
--- a/chroma_features.py
+++ b/chroma_features.py
@@ -40,7 +40,7 @@ class ChromaFeatures:
             self.audio_vector = estd.EasyLoader(filename=audio_file, sampleRate=self.fs, replayGain=-9)()
         else:
             self.audio_vector = estd.MonoLoader(filename=audio_file, sampleRate=self.fs)()
-        print "== Audio vector of %s loaded with shape %s and sample rate %s ==" % (audio_file, self.audio_vector.shape, self.fs)
+        print("== Audio vector of %s loaded with shape %s and sample rate %s ==" % (audio_file, self.audio_vector.shape, self.fs))
         return
 
 


### PR DESCRIPTION
This should effectively close #2 

qmax and dmax take around 1-2 seconds for a `(3647, 4052)` cross recurrent plot that I was testing on.

I don't know what the original runtime for qmax and dmax was on my machine because I didn't have enough patience to let it finish :)

I also added some parentheses to `print` for Python 3 compatibility.